### PR TITLE
add link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Proof-of-concept for the CoreAudio patch (CVE-2025-31200) in [iOS 18.4.1](https://support.apple.com/en-us/122282).
 
 # Update 05/21/2025
-I @noahhw46 (couldn't have done it without this setup @zhouwei) figured it out (writeup coming soon). However, there is still a lot more to understand. I added the first bit of the next steps of my investigation here in order to show exactly what the bug *does*. check-mismatch is another lldb script that can be used with a working poc to show exactly the mismatch that was created between the mRemappingArray and the permutation map in `APACChannelRemapper::Process` (really in `APACHOADecoder::DecodeAPACFrame`).
+I @noahhw46 (couldn't have done it without this setup @zhouwei) figured it out (writeup coming soon). However, there is still a lot more to understand. I added the first bit of the next steps of my investigation here in order to show exactly what the bug *does*. check-mismatch is another lldb script that can be used with a working poc to show exactly the mismatch that was created between the mRemappingArray and the [permutation](https://stackoverflow.com/a/16501453) map in `APACChannelRemapper::Process` (really in `APACHOADecoder::DecodeAPACFrame`).
 
 ----
 


### PR DESCRIPTION
Wasn't sure how clear this idea is, but the basically we have a function that permutes an input vector according to some permutation map. That is, I will change the positions of all the elements in the input vector according to some map in the, well, map argument. So if I have input vector V [A,B,C] and permutation map P [2,1,0], then permute(V,P) will be [C,B,A]. 

In our case, the function `APACChannelRemapper::Process` is actually just using the permutation map as a sort of *guide* to permute the input vector. So it looks more like:

```
float **process(struct APACChannelRemapper *self, float **inVec)
{
    const uint8_t *perm_map     = self->permDataStart;   
    const uint8_t *perm_map_end = self->permDataEnd;     

    for (uint64_t i = 0; i < (uint64_t)(perm_map_end - perm_map); ++i) {
        uint64_t j = i;

        /* follow the cycle */
        while (1) {
            j = perm_map[j];
            if (j <= i) {
                if (j != i) {               /* swap elements */
                    float *tmp = inVec[i];
                    inVec[i]     = inVec[j];
                    inVec[j]     = tmp;
                }
                break;
            }
        }
    }
    return vec;
}
```

When this function is reached the permutation map is larger: the size given by the lower two bytes of `mChannelLayoutTag`, than `self->permDataEnd - self->DataEnd`. So when the function goes to swap elements it swaps in some garbage from the heap, and swaps out what are actually pointers to floats in self-perm_map. 